### PR TITLE
Support for directories in dotfiles array

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@ dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 # dotfiles array keeps the list of dotfiles with the next format:
 #   "origin_dotfile destination_of_dotfile"
+#
+# - if the origin_dotfile is a file, it is symlinked from the destination.
+# - if the origin_dotfile is a directory, all files under it are symlinked
+#   from the same directory structure under the destination directory
 dotfiles_list=(
     "${dotfiles_dir}/bashrc ${HOME}/.bashrc"
     "${dotfiles_dir}/vimrc ${HOME}/.vimrc"

--- a/install.sh
+++ b/install.sh
@@ -105,12 +105,16 @@ function install_dotfiles() {
         destination_file=$(echo "${dotfiles[$i]}" | cut -d " " -f2)
         filename=$(basename "${origin_file}")
 
-        if [ ! -f "${origin_file}" ]; then
-            __log_warning "${filename}: not found. Skipping..."
-            continue
-        fi
+        if [ -f "${origin_file}" ]; then
+            symlink_file "${origin_file}" "${destination_file}"
 
-        symlink_file "${origin_file}" "${destination_file}"
+        elif [ -d "${origin_file}" ]; then
+            symlink_files_in_dirtree "${origin_file}" "${destination_file}"
+
+        else
+            __log_warning "${filename}: not found."
+
+        fi
     done
 }
 

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,15 @@ function install_dotfiles() {
     done
 }
 
+function symlink_files_in_dirtree() {
+    local origin_dir="$1"
+    local destination_dir="$2"
+
+    find "${origin_dir}" -type f -print0 | while IFS= read -r -d '' file; do
+        symlink_file "${file}" "${destination_dir}${file#${origin_dir}}"
+    done
+}
+
 function symlink_file() {
     local origin_file="$1"
     local destination_file="$2"


### PR DESCRIPTION
Adds support for having directory entries in the dotfiles array. When the origin is a directory, all files under that directory will be symlinked from the destination directory creating the same structure as in the origin. Any non-existing directories are created. Directories are not symlinked, only files are.