### PR TITLE
install.sh: set working dir to dir of conffile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -289,6 +289,7 @@ function read_conffile() {
 
     # shellcheck source=/dev/null
     source "${conffile}"
+    cd "$(dirname "${conffile}")" # set the working dir to the dir of the conffile
     __log_success "Found configuration file: ${conffile}"
 }
 


### PR DESCRIPTION
Fix working dir so that it is always the dir of the configuration
file. This way relative paths in the configuration file work in
a logical way.