### PR TITLE
Move user-specific installation functions from install.sh to their own scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 # TODO:
 #   - dry run option
 
-# This script assumes the use of vim-plug as vim plugin manager, with default
-# paths for files i.e. ~/.vim/plugged/
-
 dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 script_dir=scripts
 script_help_cmd="${script_dir}/help.sh"
@@ -35,7 +32,6 @@ parameter_dotfiles=false
 parameter_basic_packages=false
 parameter_packages=false
 parameter_scripts=()
-parameter_vim=false
 parameter_xfce_terminal=false
 parameter_gnome_terminal=false
 
@@ -234,56 +230,6 @@ function install_packages() {
     fi
 }
 
-function install_vim() {
-    local packages_not_installed=()
-    for package in "${basic_packages_list[@]}"; do
-        if ! check_package "${package}"; then
-            __log_info "${package}: Not installed"
-            packages_not_installed+=("${package}")
-            continue
-        fi
-    done
-
-    if [ ${#packages_not_installed[@]} -ne 0 ]; then
-        __log_warning "VIM 8: Basic packages are not installed. Skipping..."
-        __log_warning "       Please use --basic-packages in addition to --vim"
-        return
-    fi
-
-    if ! vim --version | head -n1 | grep -E "^.*IMproved 8.*" &> /dev/null; then
-        __log_info "VIM 8: Not installed"
-        echo
-        echo "Downloading and compiling VIM 8"
-        build_directory="${HOME}/buildvim8"
-        git clone https://github.com/vim/vim "${build_directory}"
-        cd "${build_directory}"
-        ./configure --prefix="${HOME}/.local/"
-        make install
-    fi
-    __log_success "VIM 8: Installed"
-
-    if [ ! -f "${HOME}/.vim/autoload/plug.vim" ]; then
-        __log_info "vim-plug: Not installed"
-        echo
-        echo "Downloading vim-plug"
-        curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
-            https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-    fi
-    __log_success "vim-plug: Installed"
-
-    vim -c 'PlugUpdate' -c 'q!' -c 'q!'
-    __log_success "vim-plug: Plugins updated"
-
-    # If we have YouCompleteMe plugin in vim, the plugin will be installed
-    # automatically, but we still need to compile the core
-    if grep -Eq "^\s*Plug .*YouCompleteMe.*$" "${HOME}/.vimrc.plugins"; then
-        "${HOME}"/.vim/plugged/YouCompleteMe/install.py
-        __log_success "YouCompleteMe: Plugin installed and core compiled"
-    else
-        __log_info "YouCompleteMe: plugin not activated in the configuration. Skipping..."
-    fi
-}
-
 function read_conffile() {
     local conffile="$1"
 
@@ -364,11 +310,6 @@ function install_main() {
         install_dotfiles "${xfce_profile[@]}"
     fi
 
-    if [ "${parameter_vim}" = true ]; then
-        echo
-        echo "Installing VIM 8 and plugins"
-        install_vim
-    fi
     echo
 }
 
@@ -382,7 +323,6 @@ If no argument is indicated, the script will not perform any action.
 List of arguments:
   --conffile conffile       Path to the configuration file to use
   --dotfiles                Install the dotfiles
-  --vim                     Install VIM 8 and VIM plugins
   --basic-packages          Install basic packages:
                                 - curl
                                 - git
@@ -418,10 +358,6 @@ while (( "$#" )); do
             ;;
         --dotfiles)
             parameter_dotfiles=true
-            shift
-            ;;
-        --vim)
-            parameter_vim=true
             shift
             ;;
         --basic-packages)

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # TODO:
 #   - dry run option
 
+# Disable unused warning because scripts might use this
+# shellcheck disable=SC2034
 dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 script_dir=scripts
 script_help_cmd="${script_dir}/help.sh"
@@ -32,7 +34,6 @@ parameter_dotfiles=false
 parameter_basic_packages=false
 parameter_packages=false
 parameter_scripts=()
-parameter_xfce_terminal=false
 
 # Log output handling from installation script of Nord theme
 # https://github.com/arcticicestudio/
@@ -264,16 +265,6 @@ function install_main() {
         run_scripts "${parameter_scripts[@]}"
     fi
 
-    if [ "${parameter_xfce_terminal}" = true ]; then
-        echo
-        echo "Installing xfce4-terminal profile"
-        local xfce_profile
-        xfce_profile=(
-            "${dotfiles_dir}/xfce4-terminal-nord.theme ${HOME}/.local/share/xfce4/terminal/colorschemes/nord.theme"
-        )
-        install_dotfiles "${xfce_profile[@]}"
-    fi
-
     echo
 }
 
@@ -296,7 +287,6 @@ List of arguments:
                                 - cmake
   --packages "package ..."  Install a list of packages
   -s, --script SCRIPTNAME   Executes script SCRIPTNAME
-  --xfce-terminal           Install the profile for xfce4-terminal
   -h, --help                Show this help.
 EOF
 
@@ -335,10 +325,6 @@ while (( "$#" )); do
         --script | -s)
             parameter_scripts+=("$2")
             shift 2
-            ;;
-        --xfce-terminal)
-            parameter_xfce_terminal=true
-            shift
             ;;
         --help | -h)
             parameter_help=true

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,6 @@ parameter_basic_packages=false
 parameter_packages=false
 parameter_scripts=()
 parameter_xfce_terminal=false
-parameter_gnome_terminal=false
 
 # Log output handling from installation script of Nord theme
 # https://github.com/arcticicestudio/
@@ -163,35 +162,6 @@ function symlink_file() {
     __log_success "${filename}: ${origin_file} -> ${destination_file}"
 }
 
-function install_gnome_terminal_profile() {
-    local gnome_profile
-    gnome_profile="${dotfiles_dir}/gnome-terminal-profile.dconf"
-    local filename
-    filename=$(basename "${gnome_profile}")
-
-    if [ ! -f "${gnome_profile}" ]; then
-        __log_warning "${filename}: not found. Skipping..."
-        return
-    fi
-
-    __log_warning "dconf utility not found. Skipping..."
-    return
-
-    # Create backup of the current profile
-    if ! dconf dump /org/gnome/terminal/legacy/profiles:/ > \
-        "${HOME}/.gnome-terminal-profile.dconf.bak" &> /dev/null; then
-        __log_error "${filename}: Cannot backup current profile"
-        __summary_error 1
-    fi
-
-    # Load the new configuration
-    if ! dconf load /org/gnome/terminal/legacy/profiles:/ < \
-        "${dotfiles_dir}/gnome-terminal-profile.dconf" &> /dev/null; then
-        __log_error "${filename}: Cannot load profile"
-        __summary_error 1
-    fi
-}
-
 function check_package() {
     local package="$1"
     if ! dpkg-query -W --showformat='${Status}\n' "${package}" | grep -q "install ok installed"; then
@@ -294,12 +264,6 @@ function install_main() {
         run_scripts "${parameter_scripts[@]}"
     fi
 
-    if [ "${parameter_gnome_terminal}" = true ]; then
-        echo
-        echo "Installing GNOME-terminal profile"
-        install_gnome_terminal_profile
-    fi
-
     if [ "${parameter_xfce_terminal}" = true ]; then
         echo
         echo "Installing xfce4-terminal profile"
@@ -332,7 +296,6 @@ List of arguments:
                                 - cmake
   --packages "package ..."  Install a list of packages
   -s, --script SCRIPTNAME   Executes script SCRIPTNAME
-  --gnome-terminal          Install the profile for GNOME-terminal
   --xfce-terminal           Install the profile for xfce4-terminal
   -h, --help                Show this help.
 EOF
@@ -372,10 +335,6 @@ while (( "$#" )); do
         --script | -s)
             parameter_scripts+=("$2")
             shift 2
-            ;;
-        --gnome-terminal)
-            parameter_gnome_terminal=true
-            shift
             ;;
         --xfce-terminal)
             parameter_xfce_terminal=true

--- a/scripts/gnome-terminal.sh
+++ b/scripts/gnome-terminal.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${dotfiles_dir:?}"
+
+function install_gnome_terminal_profile() {
+    local gnome_profile
+    gnome_profile="${dotfiles_dir}/gnome-terminal-profile.dconf"
+    local filename
+    filename=$(basename "${gnome_profile}")
+
+    if [ ! -f "${gnome_profile}" ]; then
+        __log_warning "${filename}: not found. Skipping..."
+        return
+    fi
+
+    __log_warning "dconf utility not found. Skipping..."
+    return
+
+    # Create backup of the current profile
+    if ! dconf dump /org/gnome/terminal/legacy/profiles:/ > \
+        "${HOME}/.gnome-terminal-profile.dconf.bak" &> /dev/null; then
+        __log_error "${filename}: Cannot backup current profile"
+        __summary_error 1
+    fi
+
+    # Load the new configuration
+    if ! dconf load /org/gnome/terminal/legacy/profiles:/ < \
+        "${dotfiles_dir}/gnome-terminal-profile.dconf" &> /dev/null; then
+        __log_error "${filename}: Cannot load profile"
+        __summary_error 1
+    fi
+}
+
+echo
+echo "Installing GNOME-terminal profile"
+install_gnome_terminal_profile

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -6,6 +6,7 @@ function show_script_help() {
 Available scripts:
   -s vim                    Install VIM 8 and VIM plugins
   -s gnome-terminal         Install the profile for GNOME-terminal
+  -s xfce-terminal          Install the profile for xfce4-terminal
 EOF
 }
 

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -4,7 +4,7 @@ function show_script_help() {
     cat <<EOF
 
 Available scripts:
-  There are currently no scripts available
+  -s vim                    Install VIM 8 and VIM plugins
 EOF
 }
 

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -5,6 +5,7 @@ function show_script_help() {
 
 Available scripts:
   -s vim                    Install VIM 8 and VIM plugins
+  -s gnome-terminal         Install the profile for GNOME-terminal
 EOF
 }
 

--- a/scripts/vim.sh
+++ b/scripts/vim.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${basic_packages_list:?}"
+
+# This script assumes the use of vim-plug as vim plugin manager, with default
+# paths for files i.e. ~/.vim/plugged/
+
+function install_vim() {
+    local packages_not_installed=()
+    for package in "${basic_packages_list[@]}"; do
+        if ! check_package "${package}"; then
+            __log_info "${package}: Not installed"
+            packages_not_installed+=("${package}")
+            continue
+        fi
+    done
+
+    if [ ${#packages_not_installed[@]} -ne 0 ]; then
+        __log_warning "VIM 8: Basic packages are not installed. Skipping..."
+        __log_warning "       Please use --basic-packages in addition to -s vim"
+        return
+    fi
+
+    if ! vim --version | head -n1 | grep -E "^.*IMproved 8.*" &> /dev/null; then
+        __log_info "VIM 8: Not installed"
+        echo
+        echo "Downloading and compiling VIM 8"
+        build_directory="${HOME}/buildvim8"
+        git clone https://github.com/vim/vim "${build_directory}"
+        cd "${build_directory}"
+        ./configure --prefix="${HOME}/.local/"
+        make install
+    fi
+    __log_success "VIM 8: Installed"
+
+    if [ ! -f "${HOME}/.vim/autoload/plug.vim" ]; then
+        __log_info "vim-plug: Not installed"
+        echo
+        echo "Downloading vim-plug"
+        curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+            https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    fi
+    __log_success "vim-plug: Installed"
+
+    vim -c 'PlugUpdate' -c 'q!' -c 'q!'
+    __log_success "vim-plug: Plugins updated"
+
+    # If we have YouCompleteMe plugin in vim, the plugin will be installed
+    # automatically, but we still need to compile the core
+    if grep -Eq "^\s*Plug .*YouCompleteMe.*$" "${HOME}/.vimrc.plugins"; then
+        "${HOME}"/.vim/plugged/YouCompleteMe/install.py
+        __log_success "YouCompleteMe: Plugin installed and core compiled"
+    else
+        __log_info "YouCompleteMe: plugin not activated in the configuration. Skipping..."
+    fi
+}
+
+echo
+echo "Installing VIM 8 and plugins"
+install_vim

--- a/scripts/xfce-terminal.sh
+++ b/scripts/xfce-terminal.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${dotfiles_dir:?}"
+
+function install_xfce_terminal_profile() {
+    local xfce_profile
+    xfce_profile=(
+        "${dotfiles_dir}/xfce4-terminal-nord.theme ${HOME}/.local/share/xfce4/terminal/colorschemes/nord.theme"
+    )
+    install_dotfiles "${xfce_profile[@]}"
+}
+
+echo
+echo "Installing xfce4-terminal profile"
+install_xfce_terminal_profile


### PR DESCRIPTION
Makes install.sh free of user-specific installation functions by moving those to their own scripts. After this install.sh is a tool than can be used for dotfile management and bootstrapping without including anything user-specific in install.sh itself.