### PR TITLE
Move dotfile management script into its own directory

### DIFF
--- a/.dotmgr/dotfiles.conf.example
+++ b/.dotmgr/dotfiles.conf.example
@@ -1,0 +1,28 @@
+# dotfiles_dir specifies the directory of the origin dotfiles, use either
+# an absolute path or a path relative to this configuration file
+dotfiles_dir=../dotfiles
+
+# dotfiles_list keeps the list of dotfiles with the next format:
+#   "origin_dotfile destination_of_dotfile"
+#
+# - if the origin_dotfile is a file, it is symlinked from the destination.
+# - if the origin_dotfile is a directory, all files under it are symlinked
+#   from the same directory structure under the destination directory
+dotfiles_list=(
+    "${dotfiles_dir} ${HOME}"
+)
+
+# basic_packages_list defines the packages to be installed when
+# the --basic-packages option is given
+basic_packages_list=(
+    curl
+    git
+)
+
+# script_dir specifies the directory of scripts, either an absolute
+# path or a path relative to this configuration file
+script_dir=../scripts
+
+# script_help_cmd contains the path to the script can be run to
+# insert info about available scripts to the help output
+script_help_cmd="${script_dir}/help.sh"

--- a/.dotmgr/dotmgr.sh
+++ b/.dotmgr/dotmgr.sh
@@ -273,7 +273,7 @@ function install_main() {
 
 function show_help() {
     cat <<EOF
-Usage: install.sh OPTION1 [OPTION2] ...
+Usage: dotmgr.sh OPTION1 [OPTION2] ...
 
 Install dotfiles and packages for the user.
 If no argument is indicated, the script will not perform any action.

--- a/.dotmgr/install.sh
+++ b/.dotmgr/install.sh
@@ -5,10 +5,13 @@ set -euo pipefail
 # TODO:
 #   - dry run option
 
+
+basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
 # Disable unused warning because scripts might use this
 # shellcheck disable=SC2034
-dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-script_dir=scripts
+dotfiles_dir="${basedir}/../dotfiles"
+script_dir="${basedir}/../scripts"
 script_help_cmd="${script_dir}/help.sh"
 
 # dotfiles_list keeps the list of dotfiles with the next format:
@@ -28,7 +31,7 @@ basic_packages_list=(
 packages_not_installed=()
 
 # Variables to hold calling options
-parameter_conffile="dotfiles.conf" # Set default to empty to disable the conffile and conf inline in this script
+parameter_conffile="${basedir}/../dotfiles.conf" # Set default to empty to disable the conffile and conf inline in this script
 parameter_help=false
 parameter_dotfiles=false
 parameter_basic_packages=false

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONFIG="dotfiles.conf"
+
+DOTMGR_DIR=".dotmgr"
+DOTMGR_BIN="dotmgr.sh"
+
+cd "${BASEDIR}"
+"${BASEDIR}/${DOTMGR_DIR}/${DOTMGR_BIN}" --conffile "${CONFIG}" "${@}"


### PR DESCRIPTION
Moves the original install.sh into into its own directory and inserts a new install.sh wrapper that calls the original script. This sets up a structure where the dotfile management script can be in its own repo and brought into different dotfiles repos as a submodule.