### PR TITLE
dotmgr.sh: return to working dir after running scripts

### DIFF
--- a/.dotmgr/dotmgr.sh
+++ b/.dotmgr/dotmgr.sh
@@ -229,9 +229,14 @@ function run_scripts() {
                 continue
             fi
         fi
+
+        pushd "$PWD" > /dev/null
+
         # shellcheck source=/dev/null
         source "${script_path}"
         __log_success "${script}: Script was executed"
+
+        popd > /dev/null  # Make sure we are always at the working dir after script execution
     done
 }
 


### PR DESCRIPTION
Improve robustness by always returning to the original working
directory after running a script.