### PR TITLE
Prevent sourcing dotmgr.sh

### DIFF
--- a/dotmgr.sh
+++ b/dotmgr.sh
@@ -31,19 +31,8 @@ parameter_dry_run=false
 parameter_packages=false
 parameter_scripts=()
 
-# Log output handling from installation script of Nord theme
+# Log output handling originally from installation script of Nord theme
 # https://github.com/arcticicestudio/
-
-# Not yet used, commented to prevent shellcheck warnings, uncomment when needed
-#_ct_error="\e[0;31m"
-#_ct_success="\e[0;32m"
-#_ct_warning="\e[0;33m"
-#_ct_highlight="\e[0;34m"
-#_ct_primary="\e[0;36m"
-#_ctb_subtle="\e[1;30m"
-#_ctb_highlight="\e[1;34m"
-#_ctb_primary="\e[1;36m"
-
 _ct="\e[0;37m"
 _ctb_error="\e[1;31m"
 _ctb_success="\e[1;32m"
@@ -51,15 +40,6 @@ _ctb_warning="\e[1;33m"
 _ctb="\e[1;37m"
 _c_reset="\e[0m"
 _ctb_reset="\e[0m"
-
-__cleanup() {
-  trap '' SIGINT SIGTERM
-  unset -v _ct_error _ct_success _ct_warning _ct_highlight _ct_primary _ct
-  unset -v _ctb_error _ctb_success _ctb_warning _ctb_highlight _ctb_primary _ctb _c_reset
-  unset -v NORD_XFCE_TERMINAL_SCRIPT_OPTS THEME_FILE VERBOSE LOCAL_INSTALL NORD_XFCE_TERMINAL_VERSION
-  unset -f __help __cleanup __log_error __log_success __log_warning __log_info
-  unset -f __validate_file __local_install
-}
 
 __log_error() {
   printf "%b" "${_ctb_error}[ERROR] ${_ct}$1${_c_reset}\n" | tee -a "${log_file}"
@@ -79,7 +59,6 @@ __log_info() {
 
 __summary_success() {
   __log_success "Local installation completed"
-  __cleanup
   exit 0
 }
 
@@ -87,7 +66,6 @@ __summary_error() {
   __log_error "An error occurred during the installation!"
   __log_error "Log file: ${log_file}"
   __log_error "Exit code: $1"
-  __cleanup
   exit 1
 }
 
@@ -369,4 +347,3 @@ while (( "$#" )); do
 done
 
 install_main
-__cleanup

--- a/dotmgr.sh
+++ b/dotmgr.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Don't allow sourcing this script
+(return 0 2>/dev/null) && echo "ERROR: ${BASH_SOURCE[0]##*/} must not be sourced!" && return 1
+
 set -euo pipefail
 
 basedir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"


### PR DESCRIPTION
Prevents sourcing dotmgr.sh as there should be no viable use case for this. The script both contains exit commands and sources other user-defined scripts, neither goes well with sourcing.

Since the script cannot be sourced, the __cleanup function has no use and is removed.

Depends on #25